### PR TITLE
bug fix: star_cmd -> tar_cmd in line 349

### DIFF
--- a/batch/batch.py
+++ b/batch/batch.py
@@ -346,7 +346,7 @@ class BatchController(object):
             if self.plot:
                 cmd = ";".join((cmd, plot_cmd))
                 if self.tar:
-                    cmd = ";".join((cmd, star_cmd))
+                    cmd = ";".join((cmd, tar_cmd))
 
             # Run jobs
             if self.parallel:


### PR DESCRIPTION
Hi Kyle, 

This is a typo in `batch.py`. Line 349 had previously included `star_cmd`. I corrected it to `tar_cmd`:

```
Traceback (most recent call last):
  File "/home/hugh/Downloads/run_faults.py", line 70, in <module>
    controller.run()
  File "/home/hugh/Documents/DEV/batch/batch/batch.py", line 349, in run
    cmd = ";".join((cmd, star_cmd))
```