### PR TITLE
Add batch.packed: fan a sweep across exclusive nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+
+### Added
+- `batch.packed`: fan a parameter sweep across several exclusive nodes, packing
+  many runs onto each via the local pool with CPU pinning.  `submit_packed()`
+  renders one per-node wrapper (PBS or SLURM) and submits it; the pure
+  `render_packed_pbs_wrapper()` / `render_packed_slurm_wrapper()` functions are
+  unit-testable without a cluster.  `PackedResources` is the scheduler-agnostic
+  per-node resource request.
+- `batch.sweep.shard_jobs(jobs, i, n)` and `parse_shard_spec("i/n")`: split a job
+  list into disjoint round-robin shards, one per packed node.
+
 ## [2.0.0] — breaking API change
 
 ### Added

--- a/batch/__init__.py
+++ b/batch/__init__.py
@@ -8,7 +8,8 @@ The most commonly used names are re-exported here for convenience::
     from batch import SerialExecutor, ParallelExecutor
     from batch import SLURMExecutor, SLURMResources
     from batch import PBSExecutor, PBSResources
-    from batch.sweep import product_sweep, zip_sweep
+    from batch import PackedResources, submit_packed
+    from batch.sweep import product_sweep, zip_sweep, shard_jobs
 """
 
 from batch.controller import BatchController
@@ -16,7 +17,9 @@ from batch.executors.local import ParallelExecutor, SerialExecutor
 from batch.executors.pbs import PBSExecutor, PBSResources
 from batch.executors.slurm import SLURMExecutor, SLURMResources
 from batch.job import ClobberPolicy, Job, JobPaths, JobResult
+from batch.packed import PackedResources, submit_packed
 from batch.plot import plot_job
+from batch.sweep import shard_jobs
 
 __version__ = "2.0.0"
 
@@ -32,5 +35,8 @@ __all__ = [
     "SLURMResources",
     "PBSExecutor",
     "PBSResources",
+    "PackedResources",
+    "submit_packed",
+    "shard_jobs",
     "plot_job",
 ]

--- a/batch/packed.py
+++ b/batch/packed.py
@@ -1,0 +1,302 @@
+"""Packed submission: fan a sweep across several exclusive nodes.
+
+A single GeoClaw run rarely saturates a modern HPC node, so instead of one
+scheduler job per run (see :mod:`batch.executors.pbs` /
+:mod:`batch.executors.slurm`) you can *pack* many runs onto each of ``n`` nodes.
+Each node requests one exclusive node and, on the compute node, runs a disjoint
+shard of the job list through the local :class:`~batch.executors.local.ParallelExecutor`
+with ``cpu_affinity=True`` (see :func:`batch.sweep.shard_jobs`).
+
+Because packing re-runs the *caller's* driver script on the compute node — the
+job-definition code has to be present there to build/plot each run — the inner
+per-node command is supplied by the caller rather than owned here.  This module
+provides the reusable outer layer: rendering the per-node wrapper script and
+submitting the wrappers with ``qsub`` / ``sbatch``.
+
+The renderers are pure functions (no filesystem, no subprocess), so they are
+unit-testable without a cluster, mirroring ``render_pbs_script`` /
+``render_slurm_script``.
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Literal
+
+logger = logging.getLogger(__name__)
+
+Scheduler = Literal["pbs", "slurm"]
+
+# (shard_i, n_shards) -> argv list for the per-node re-invocation of the driver.
+InnerCommand = Callable[[int, int], Sequence[str]]
+
+
+@dataclass
+class PackedResources:
+    """Resource request for one exclusive node in a packed submission.
+
+    Scheduler-agnostic: the same object renders to ``#PBS`` or ``#SBATCH``
+    directives depending on the ``scheduler`` argument to :func:`submit_packed`.
+
+    Parameters
+    ----------
+    queue:
+        Queue / partition name (PBS ``-q`` or SLURM ``-p``).
+    walltime:
+        Walltime limit in ``HH:MM:SS`` format.
+    account:
+        Allocation project code (``-A``).  The directive is omitted when empty.
+    node_cpus:
+        Cores to request on the (exclusive) node.  On Derecho CPU nodes, 128.
+    modules:
+        Module names to ``module load`` in the wrapper before the inner command.
+    extra_directives:
+        Raw ``#PBS`` / ``#SBATCH`` lines appended after the standard directives.
+    """
+
+    queue: str = "main"
+    walltime: str = "12:00:00"
+    account: str = ""
+    node_cpus: int = 128
+    modules: list[str] = field(default_factory=list)
+    extra_directives: list[str] = field(default_factory=list)
+
+
+def _wrapper_body(
+    resources: PackedResources,
+    inner: Sequence[str],
+    workdir: Path | str | None,
+) -> list[str]:
+    """Shared script body: module loads, optional cd, and the inner command."""
+    lines: list[str] = [""]
+    if resources.modules:
+        lines.extend(f"module load {m}" for m in resources.modules)
+        lines.append("")
+    if workdir is not None:
+        lines.append(f"cd {workdir}")
+    lines.append(" ".join(str(a) for a in inner))
+    lines.append("")  # trailing newline
+    return lines
+
+
+def render_packed_pbs_wrapper(
+    shard_i: int,
+    n_shards: int,
+    inner_command: Sequence[str],
+    resources: PackedResources,
+    *,
+    name: str,
+    log_path: Path | str,
+    workdir: Path | str | None = None,
+) -> str:
+    """Render a PBS wrapper that packs one shard onto one exclusive node.
+
+    The wrapper requests a single node with ``node_cpus`` cores
+    (``mpiprocs=1:ompthreads=1`` — the packing is done by the local pool inside
+    the inner command, not by MPI) and runs *inner_command* on the compute node.
+
+    Parameters
+    ----------
+    shard_i, n_shards:
+        This node's 1-based shard index and the total shard count (used only for
+        the default job name / logging; the caller's *inner_command* is
+        responsible for actually selecting the shard).
+    inner_command:
+        The per-node command to run on the compute node, as an argv sequence.
+    resources:
+        Node resource request.
+    name:
+        PBS job name (``-N``).
+    log_path:
+        Joined stdout/stderr log path (``-o`` with ``-j oe``).
+    workdir:
+        Directory to ``cd`` into before running the inner command.  When None,
+        no ``cd`` is emitted (the scheduler's default working directory is used).
+
+    Returns
+    -------
+    str
+        Complete wrapper script text.
+    """
+    chunk = f"1:ncpus={resources.node_cpus}:mpiprocs=1:ompthreads=1"
+    directives = [
+        f"#PBS -N {name}",
+        f"#PBS -o {log_path}",
+        "#PBS -j oe",
+        f"#PBS -q {resources.queue}",
+        f"#PBS -l select={chunk}",
+        f"#PBS -l walltime={resources.walltime}",
+    ]
+    if resources.account:
+        directives.append(f"#PBS -A {resources.account}")
+    directives.extend(resources.extra_directives)
+
+    lines = ["#!/bin/bash"] + directives
+    lines.extend(_wrapper_body(resources, inner_command, workdir))
+    return "\n".join(lines)
+
+
+def render_packed_slurm_wrapper(
+    shard_i: int,
+    n_shards: int,
+    inner_command: Sequence[str],
+    resources: PackedResources,
+    *,
+    name: str,
+    log_path: Path | str,
+    workdir: Path | str | None = None,
+) -> str:
+    """Render a SLURM wrapper that packs one shard onto one exclusive node.
+
+    The SLURM analogue of :func:`render_packed_pbs_wrapper`: requests one
+    exclusive node (``-N 1 --exclusive``) and runs *inner_command* on it.
+
+    Parameters
+    ----------
+    shard_i, n_shards, inner_command, resources, name, log_path, workdir:
+        See :func:`render_packed_pbs_wrapper`.
+
+    Returns
+    -------
+    str
+        Complete wrapper script text.
+    """
+    directives = [
+        f"#SBATCH -J {name}",
+        f"#SBATCH -o {log_path}",
+        f"#SBATCH -e {log_path}",
+        f"#SBATCH -p {resources.queue}",
+        "#SBATCH -N 1",
+        "#SBATCH --exclusive",
+        "#SBATCH --ntasks-per-node=1",
+        f"#SBATCH --cpus-per-task={resources.node_cpus}",
+        f"#SBATCH -t {resources.walltime}",
+    ]
+    if resources.account:
+        directives.append(f"#SBATCH -A {resources.account}")
+    directives.extend(resources.extra_directives)
+
+    lines = ["#!/bin/bash"] + directives
+    lines.extend(_wrapper_body(resources, inner_command, workdir))
+    return "\n".join(lines)
+
+
+_RENDERERS = {
+    "pbs": render_packed_pbs_wrapper,
+    "slurm": render_packed_slurm_wrapper,
+}
+_SUBMIT_CMD = {"pbs": "qsub", "slurm": "sbatch"}
+
+
+def submit_packed(
+    n_nodes: int,
+    inner_command: InnerCommand,
+    resources: PackedResources,
+    scheduler: Scheduler,
+    script_dir: Path | str,
+    *,
+    dry_run: bool = False,
+    name_prefix: str = "pack",
+    workdir: Path | str | None = None,
+) -> list[str]:
+    """Render one wrapper per node and (unless *dry_run*) submit them.
+
+    Submit-and-exit: each node's wrapper self-packs its shard via the caller's
+    local-mode re-invocation.  Nothing is waited on here — poll the queue
+    yourself, and run any cross-run post-processing once the jobs finish.
+
+    Parameters
+    ----------
+    n_nodes:
+        Number of exclusive nodes to fan the sweep over (one submission each).
+    inner_command:
+        Callable ``(shard_i, n_shards) -> argv`` returning the per-node command
+        to run on the compute node.  Typically re-invokes the driver script in
+        ``--scheduler local --shard i/n --pin-cpus`` mode.
+    resources:
+        Per-node resource request.
+    scheduler:
+        ``"pbs"`` or ``"slurm"``.
+    script_dir:
+        Directory to write the generated wrapper scripts into (created if
+        missing).
+    dry_run:
+        When True, write the wrapper scripts but do not call ``qsub`` / ``sbatch``.
+    name_prefix:
+        Prefix for job names and script filenames (``<prefix>_<i>of<n>``).
+    workdir:
+        Directory each wrapper ``cd``s into before the inner command.
+
+    Returns
+    -------
+    list[str]
+        Submitted scheduler job IDs, or — under *dry_run* — the paths of the
+        wrapper scripts written.
+
+    Raises
+    ------
+    ValueError
+        If ``n_nodes < 1`` or *scheduler* is unknown.
+    SystemExit
+        If ``qsub`` / ``sbatch`` rejects a submission (the message is surfaced
+        and remaining nodes are not fired at the same wall).
+    """
+    if n_nodes < 1:
+        raise ValueError(f"n_nodes must be >= 1; got {n_nodes}")
+    if scheduler not in _RENDERERS:
+        raise ValueError(
+            f"scheduler must be one of {sorted(_RENDERERS)}; got {scheduler!r}"
+        )
+
+    render = _RENDERERS[scheduler]
+    submit_cmd = _SUBMIT_CMD[scheduler]
+    script_dir = Path(script_dir)
+    script_dir.mkdir(parents=True, exist_ok=True)
+
+    out: list[str] = []
+    for i in range(1, n_nodes + 1):
+        name = f"{name_prefix}_{i}of{n_nodes}"
+        script_path = script_dir / f"{name}_run.sh"
+        script = render(
+            i,
+            n_nodes,
+            inner_command(i, n_nodes),
+            resources,
+            name=name,
+            log_path=script_dir / f"{name}_log.txt",
+            workdir=workdir,
+        )
+        script_path.write_text(script)
+        logger.debug("Wrote packed wrapper: %s", script_path)
+
+        if dry_run:
+            logger.info("[dry-run] Would submit: %s", script_path)
+            out.append(str(script_path))
+            continue
+
+        proc = subprocess.run(
+            [submit_cmd, str(script_path)],
+            capture_output=True,
+            text=True,
+        )
+        if proc.returncode != 0:
+            # Surface the scheduler's own rejection (account/queue/walltime, etc.)
+            # and stop rather than firing the remaining nodes at the same wall.
+            msg = (
+                proc.stderr.strip()
+                or proc.stdout.strip()
+                or f"({submit_cmd} produced no output)"
+            )
+            raise SystemExit(
+                f"{submit_cmd} failed for {script_path} "
+                f"(exit {proc.returncode}):\n{msg}"
+            )
+        job_id = proc.stdout.strip()
+        logger.info("Submitted packed shard %d/%d -> job %s", i, n_nodes, job_id)
+        out.append(job_id)
+
+    return out

--- a/batch/sweep.py
+++ b/batch/sweep.py
@@ -108,3 +108,80 @@ def zip_sweep(
         job.prefix = namer(params)
         jobs.append(job)
     return jobs
+
+
+def parse_shard_spec(spec: str) -> tuple[int, int]:
+    """Parse a 1-based ``"I/N"`` shard spec into ``(i, n)``.
+
+    An empty string means "no sharding" and returns ``(1, 1)``.  Used to split a
+    job list across nodes: shard ``i`` of ``n`` (see :func:`shard_jobs`).
+
+    Parameters
+    ----------
+    spec:
+        Either an empty string or ``"I/N"`` with ``1 <= I <= N`` and ``N >= 1``.
+
+    Returns
+    -------
+    tuple[int, int]
+        The ``(i, n)`` pair.
+
+    Raises
+    ------
+    ValueError
+        If *spec* is malformed or out of range.
+
+    Examples
+    --------
+    >>> parse_shard_spec("3/16")
+    (3, 16)
+    >>> parse_shard_spec("")
+    (1, 1)
+    """
+    if not spec:
+        return 1, 1
+    try:
+        i_str, n_str = spec.split("/")
+        i, n = int(i_str), int(n_str)
+    except ValueError:
+        raise ValueError(f"shard spec must be I/N (e.g. 1/16); got {spec!r}") from None
+    if n < 1 or not (1 <= i <= n):
+        raise ValueError(
+            f"shard spec I/N requires N >= 1 and 1 <= I <= N; got {spec!r}"
+        )
+    return i, n
+
+
+def shard_jobs(jobs: list[Job], i: int, n: int) -> list[Job]:
+    """Return shard *i* of *n* from *jobs*, round-robin (1-based).
+
+    Splitting the job list this way lets each of *n* nodes run a disjoint slice
+    of the same sweep: node ``i`` runs ``shard_jobs(jobs, i, n)``.  Round-robin
+    (``jobs[i-1::n]``) rather than contiguous blocks keeps the per-shard work
+    balanced when jobs are ordered by cost.
+
+    The *n* shards are disjoint and their union is *jobs*, so no job is dropped
+    or duplicated across nodes.
+
+    Parameters
+    ----------
+    jobs:
+        The full job list.
+    i:
+        1-based shard index, ``1 <= i <= n``.
+    n:
+        Number of shards, ``n >= 1``.
+
+    Returns
+    -------
+    list[Job]
+        The jobs assigned to shard *i*.
+
+    Raises
+    ------
+    ValueError
+        If ``n < 1`` or ``i`` is out of ``[1, n]``.
+    """
+    if n < 1 or not (1 <= i <= n):
+        raise ValueError(f"shard requires n >= 1 and 1 <= i <= n; got i={i}, n={n}")
+    return jobs[i - 1 :: n]

--- a/docs/running-on-hpc.md
+++ b/docs/running-on-hpc.md
@@ -158,11 +158,53 @@ the same cores.
 - Requires `numactl` on `PATH` (Linux/HPC). Leave `cpu_affinity=False` on
   machines without it (e.g. macOS).
 
-To run this *on* a node, submit a wrapper job that requests one exclusive node
-and then invokes your driver in local mode on the compute node. To fan a large
-sweep across several packed nodes at once, split the job list into shards (one
-node per shard) — a reusable helper for this is planned; for now see the
-`pbs-packed` pattern in the project drivers.
+### Fanning a sweep across several packed nodes
+
+To pack on more than one node at once, split the job list into shards — one node
+per shard — and submit a wrapper per node. `batch.submit_packed` renders and
+submits those wrappers; each wrapper re-invokes *your own driver* on the compute
+node in local mode over its shard. (It has to re-run your driver because your
+`Job`-definition code — `build` / `post_run` — must be present on the node;
+`batch` supplies the outer packing layer, not your job definitions.)
+
+```python
+import sys
+from pathlib import Path
+from batch import submit_packed, PackedResources, shard_jobs
+
+# In your driver's local path, select this node's shard of the full sweep:
+#   i, n = parse_shard_spec(args.shard)      # from batch.sweep
+#   jobs = shard_jobs(all_jobs, i, n)
+# and run them through ParallelExecutor(cpu_affinity=True) as above.
+
+def inner(shard_i, n_shards):
+    """Per-node command: re-run this driver in local mode over one shard."""
+    return [
+        sys.executable, __file__,
+        "--scheduler", "local",
+        "--shard", f"{shard_i}/{n_shards}",
+        "--pin-cpus",
+    ]
+
+submit_packed(
+    n_nodes=4,
+    inner_command=inner,
+    resources=PackedResources(
+        queue="main", walltime="12:00:00", account="NCAR0001",
+        node_cpus=128, modules=["ncarenv/23.09", "conda"],
+    ),
+    scheduler="pbs",                    # or "slurm"
+    script_dir=Path("_pack_scripts"),
+    dry_run=False,                      # True writes wrappers without submitting
+    workdir=Path(__file__).parent,
+)
+```
+
+`submit_packed` returns the submitted job IDs (or, under `dry_run=True`, the paths
+of the wrapper scripts it wrote so you can inspect the directives first). It is
+submit-and-exit — poll the queue yourself and build any cross-run figures once
+the jobs finish. `shard_jobs(jobs, i, n)` and `parse_shard_spec("i/n")` (both in
+`batch.sweep`) give each node a disjoint, balanced slice of the sweep.
 
 ---
 

--- a/tests/test_packed.py
+++ b/tests/test_packed.py
@@ -1,0 +1,212 @@
+"""Tests for batch.packed.
+
+The wrapper renderers are pure functions, so all rendering tests run without a
+cluster.  submit_packed is exercised with dry_run=True and by patching
+subprocess.run, mirroring the SLURM/PBS executor dry-run tests.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from batch.packed import (
+    PackedResources,
+    render_packed_pbs_wrapper,
+    render_packed_slurm_wrapper,
+    submit_packed,
+)
+
+
+def inner(shard_i: int, n_shards: int) -> list[str]:
+    """A representative per-node inner command."""
+    return [
+        "python",
+        "driver.py",
+        "--scheduler",
+        "local",
+        "--shard",
+        f"{shard_i}/{n_shards}",
+        "--pin-cpus",
+    ]
+
+
+@pytest.fixture
+def resources() -> PackedResources:
+    return PackedResources(
+        queue="main",
+        walltime="12:00:00",
+        account="NCAR0001",
+        node_cpus=128,
+        modules=["ncarenv/23.09", "conda"],
+    )
+
+
+# ---------------------------------------------------------------------------
+# render_packed_pbs_wrapper
+# ---------------------------------------------------------------------------
+
+
+class TestRenderPackedPBSWrapper:
+    def _render(self, resources, **kw):
+        kw.setdefault("name", "pack_1of4")
+        kw.setdefault("log_path", "/scratch/pack_1of4_log.txt")
+        return render_packed_pbs_wrapper(1, 4, inner(1, 4), resources, **kw)
+
+    def test_starts_with_shebang(self, resources):
+        assert self._render(resources).startswith("#!/bin/bash")
+
+    def test_exclusive_single_node_chunk(self, resources):
+        script = self._render(resources)
+        assert "#PBS -l select=1:ncpus=128:mpiprocs=1:ompthreads=1" in script
+
+    def test_name_and_log_and_join(self, resources):
+        script = self._render(resources)
+        assert "#PBS -N pack_1of4" in script
+        assert "#PBS -o /scratch/pack_1of4_log.txt" in script
+        assert "#PBS -j oe" in script
+
+    def test_queue_and_walltime(self, resources):
+        script = self._render(resources)
+        assert "#PBS -q main" in script
+        assert "#PBS -l walltime=12:00:00" in script
+
+    def test_account_present_when_set(self, resources):
+        assert "#PBS -A NCAR0001" in self._render(resources)
+
+    def test_account_absent_when_empty(self, resources):
+        resources.account = ""
+        assert "#PBS -A" not in self._render(resources)
+
+    def test_modules_loaded(self, resources):
+        script = self._render(resources)
+        assert "module load ncarenv/23.09" in script
+        assert "module load conda" in script
+
+    def test_inner_command_present(self, resources):
+        script = self._render(resources)
+        assert "python driver.py --scheduler local --shard 1/4 --pin-cpus" in script
+
+    def test_cd_workdir_present_when_given(self, resources):
+        script = self._render(resources, workdir="/home/me/proj")
+        assert "cd /home/me/proj" in script
+
+    def test_no_cd_when_workdir_none(self, resources):
+        assert "\ncd " not in self._render(resources)
+
+    def test_extra_directives_appended(self, resources):
+        resources.extra_directives = ["#PBS -l job_priority=premium"]
+        assert "#PBS -l job_priority=premium" in self._render(resources)
+
+    def test_ends_with_newline(self, resources):
+        assert self._render(resources).endswith("\n")
+
+
+# ---------------------------------------------------------------------------
+# render_packed_slurm_wrapper
+# ---------------------------------------------------------------------------
+
+
+class TestRenderPackedSlurmWrapper:
+    def _render(self, resources, **kw):
+        kw.setdefault("name", "pack_1of4")
+        kw.setdefault("log_path", "/scratch/pack_1of4_log.txt")
+        return render_packed_slurm_wrapper(1, 4, inner(1, 4), resources, **kw)
+
+    def test_exclusive_single_node(self, resources):
+        script = self._render(resources)
+        assert "#SBATCH -N 1" in script
+        assert "#SBATCH --exclusive" in script
+        assert "#SBATCH --cpus-per-task=128" in script
+
+    def test_partition_and_walltime(self, resources):
+        script = self._render(resources)
+        assert "#SBATCH -p main" in script
+        assert "#SBATCH -t 12:00:00" in script
+
+    def test_account_present_when_set(self, resources):
+        assert "#SBATCH -A NCAR0001" in self._render(resources)
+
+    def test_account_absent_when_empty(self, resources):
+        resources.account = ""
+        assert "#SBATCH -A" not in self._render(resources)
+
+    def test_inner_command_present(self, resources):
+        script = self._render(resources)
+        assert "python driver.py --scheduler local --shard 1/4 --pin-cpus" in script
+
+    def test_ends_with_newline(self, resources):
+        assert self._render(resources).endswith("\n")
+
+
+# ---------------------------------------------------------------------------
+# submit_packed
+# ---------------------------------------------------------------------------
+
+
+class TestSubmitPacked:
+    def test_dry_run_writes_n_scripts(self, resources, tmp_path: Path):
+        out = submit_packed(
+            3, inner, resources, "pbs", tmp_path, dry_run=True, name_prefix="pack"
+        )
+        assert len(out) == 3
+        for i in range(1, 4):
+            assert (tmp_path / f"pack_{i}of3_run.sh").exists()
+        # Returned values are the script paths under dry_run.
+        assert all(str(tmp_path) in p for p in out)
+
+    def test_dry_run_does_not_submit(self, resources, tmp_path: Path):
+        from unittest.mock import patch
+
+        with patch("batch.packed.subprocess.run") as mock_run:
+            submit_packed(2, inner, resources, "pbs", tmp_path, dry_run=True)
+        mock_run.assert_not_called()
+
+    def test_inner_command_receives_shard_indices(self, resources, tmp_path: Path):
+        seen = []
+
+        def spy(i, n):
+            seen.append((i, n))
+            return inner(i, n)
+
+        submit_packed(3, spy, resources, "slurm", tmp_path, dry_run=True)
+        assert seen == [(1, 3), (2, 3), (3, 3)]
+
+    def test_pbs_calls_qsub_per_node(self, resources, tmp_path: Path):
+        from unittest.mock import MagicMock, patch
+
+        with patch("batch.packed.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="123.desched\n")
+            out = submit_packed(2, inner, resources, "pbs", tmp_path)
+        assert mock_run.call_count == 2
+        assert mock_run.call_args_list[0].args[0][0] == "qsub"
+        assert out == ["123.desched", "123.desched"]
+
+    def test_slurm_calls_sbatch(self, resources, tmp_path: Path):
+        from unittest.mock import MagicMock, patch
+
+        with patch("batch.packed.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="456\n")
+            submit_packed(1, inner, resources, "slurm", tmp_path)
+        assert mock_run.call_args_list[0].args[0][0] == "sbatch"
+
+    def test_submit_failure_raises_system_exit(self, resources, tmp_path: Path):
+        from unittest.mock import MagicMock, patch
+
+        with patch("batch.packed.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=1, stdout="", stderr="qsub: bad account\n"
+            )
+            with pytest.raises(SystemExit, match="bad account"):
+                submit_packed(3, inner, resources, "pbs", tmp_path)
+        # Stops on the first failure rather than firing all three.
+        assert mock_run.call_count == 1
+
+    def test_invalid_n_nodes_raises(self, resources, tmp_path: Path):
+        with pytest.raises(ValueError):
+            submit_packed(0, inner, resources, "pbs", tmp_path, dry_run=True)
+
+    def test_unknown_scheduler_raises(self, resources, tmp_path: Path):
+        with pytest.raises(ValueError):
+            submit_packed(1, inner, resources, "lsf", tmp_path, dry_run=True)

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import pytest
 
 from batch.job import Job
-from batch.sweep import product_sweep, zip_sweep
+from batch.sweep import parse_shard_spec, product_sweep, shard_jobs, zip_sweep
 from tests.conftest import MockJob
 
 
@@ -141,3 +141,64 @@ class TestZipSweep:
         )
         assert jobs[0]._params == {"a": 1, "b": "x"}
         assert jobs[1]._params == {"a": 2, "b": "y"}
+
+
+# ---------------------------------------------------------------------------
+# parse_shard_spec
+# ---------------------------------------------------------------------------
+
+
+class TestParseShardSpec:
+    def test_empty_is_no_sharding(self):
+        assert parse_shard_spec("") == (1, 1)
+
+    def test_valid_spec(self):
+        assert parse_shard_spec("3/16") == (3, 16)
+
+    @pytest.mark.parametrize("spec", ["1", "1/2/3", "a/2", "1-2"])
+    def test_malformed_raises(self, spec):
+        with pytest.raises(ValueError):
+            parse_shard_spec(spec)
+
+    @pytest.mark.parametrize("spec", ["0/4", "5/4", "1/0", "-1/4"])
+    def test_out_of_range_raises(self, spec):
+        with pytest.raises(ValueError):
+            parse_shard_spec(spec)
+
+
+# ---------------------------------------------------------------------------
+# shard_jobs
+# ---------------------------------------------------------------------------
+
+
+class TestShardJobs:
+    def test_single_shard_returns_all(self):
+        jobs = [MockJob(prefix=str(k)) for k in range(10)]
+        assert shard_jobs(jobs, 1, 1) == jobs
+
+    def test_shards_are_disjoint_and_cover_all(self):
+        jobs = [MockJob(prefix=str(k)) for k in range(10)]
+        n = 3
+        collected = []
+        for i in range(1, n + 1):
+            collected.extend(shard_jobs(jobs, i, n))
+        # Every job appears exactly once across the shards.
+        assert sorted(j.prefix for j in collected) == sorted(j.prefix for j in jobs)
+        assert len(collected) == len(jobs)
+
+    def test_round_robin_order(self):
+        jobs = [MockJob(prefix=str(k)) for k in range(6)]
+        assert [j.prefix for j in shard_jobs(jobs, 1, 3)] == ["0", "3"]
+        assert [j.prefix for j in shard_jobs(jobs, 2, 3)] == ["1", "4"]
+        assert [j.prefix for j in shard_jobs(jobs, 3, 3)] == ["2", "5"]
+
+    def test_more_shards_than_jobs_gives_empty_tail(self):
+        jobs = [MockJob(prefix=str(k)) for k in range(2)]
+        assert [j.prefix for j in shard_jobs(jobs, 1, 4)] == ["0"]
+        assert [j.prefix for j in shard_jobs(jobs, 2, 4)] == ["1"]
+        assert shard_jobs(jobs, 3, 4) == []
+
+    @pytest.mark.parametrize("i,n", [(0, 3), (4, 3), (1, 0)])
+    def test_out_of_range_raises(self, i, n):
+        with pytest.raises(ValueError):
+            shard_jobs([], i, n)


### PR DESCRIPTION
## What

Adds `batch.packed`, the reusable outer layer for **packed submission** — fanning
a parameter sweep across `N` exclusive nodes, packing many runs onto each node
via the local `ParallelExecutor` with CPU pinning (which already exists as
`cpu_affinity=True`). This generalizes the `pbs-packed` machinery that had been
living in per-project driver scripts so it doesn't get copied into every project.

## API

- **`submit_packed(n_nodes, inner_command, resources, scheduler, script_dir, *, dry_run=…)`**
  — renders one per-node wrapper (PBS or SLURM) and submits it. Submit-and-exit;
  returns job IDs (or wrapper paths under `dry_run`).
- **`PackedResources`** — scheduler-agnostic per-node resource request
  (`queue`, `walltime`, `account`, `node_cpus`, `modules`, `extra_directives`).
- **`render_packed_pbs_wrapper` / `render_packed_slurm_wrapper`** — pure functions,
  unit-testable without a cluster (mirroring `render_pbs_script` / `render_slurm_script`).
- **`batch.sweep.shard_jobs(jobs, i, n)`** and **`parse_shard_spec("i/n")`** —
  disjoint round-robin sharding, one shard per node.

The per-node inner command is caller-supplied: packing re-invokes the caller's
own driver on the compute node (its `Job` code must build/plot each run there),
so `batch` supplies the packing layer, not the job definitions. Both PBS and
SLURM are supported for parity.

## Tests

`tests/test_packed.py` (renderer directive correctness for both schedulers;
`submit_packed` dry-run writes N scripts and doesn't submit; patched `qsub`/`sbatch`
paths; failure raises `SystemExit` and stops early) and `tests/test_sweep.py`
additions (shard disjoint-union coverage, round-robin order, range validation).

Full suite: 174 passed; `ruff check` + `ruff format` clean. No new dependencies.

## Follow-ups

Adopting this in the ETC `run_tests.py` (replacing its local packed copielands
with PR 3 (`batch.cli`), which builds the `execute()` dispatch on top of `submit_packed`.

Note: the docs example refrom batch.sweep for thelocal-shard side; that ties in fully once PR 3's execute() wires sharding into the local path.