### PR TITLE
Add batch.cli: shared execution CLI (factories + execute)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### Added
+- `batch.cli`: shared command-line surface for driver scripts, so projects stop
+  copy-pasting the scheduler/resource argparse block and the arg→executor glue.
+  `add_execution_args(parser)` contributes the generic flag group;
+  `executor_from_args(args)` / `clobber_from_args(args)` map args to objects;
+  `report_results(results)` prints and returns a `ResultSummary`; and
+  `execute(args, jobs, ...)` is a thin dispatch over local / scheduler / packed
+  submission.  Projects keep their own `main()` and domain flags.
 - `batch.packed`: fan a parameter sweep across several exclusive nodes, packing
   many runs onto each via the local pool with CPU pinning.  `submit_packed()`
   renders one per-node wrapper (PBS or SLURM) and submits it; the pure

--- a/batch/__init__.py
+++ b/batch/__init__.py
@@ -9,9 +9,18 @@ The most commonly used names are re-exported here for convenience::
     from batch import SLURMExecutor, SLURMResources
     from batch import PBSExecutor, PBSResources
     from batch import PackedResources, submit_packed
+    from batch import add_execution_args, executor_from_args, execute, report_results
     from batch.sweep import product_sweep, zip_sweep, shard_jobs
 """
 
+from batch.cli import (
+    ResultSummary,
+    add_execution_args,
+    clobber_from_args,
+    execute,
+    executor_from_args,
+    report_results,
+)
 from batch.controller import BatchController
 from batch.executors.local import ParallelExecutor, SerialExecutor
 from batch.executors.pbs import PBSExecutor, PBSResources
@@ -39,4 +48,10 @@ __all__ = [
     "submit_packed",
     "shard_jobs",
     "plot_job",
+    "add_execution_args",
+    "executor_from_args",
+    "clobber_from_args",
+    "execute",
+    "report_results",
+    "ResultSummary",
 ]

--- a/batch/cli.py
+++ b/batch/cli.py
@@ -1,0 +1,393 @@
+"""Shared command-line surface for batch driver scripts.
+
+Every HPC driver ends up re-implementing the same scheduler/resource argparse
+block, the same ``--resume`` → :class:`~batch.job.ClobberPolicy` mapping, and the
+same success/failure report.  This module factors that out **without** owning
+your ``main()``: you keep your own :class:`argparse.ArgumentParser`, add your
+domain flags to it, and build the job list yourself.  The pieces are layered so
+you can use as much or as little as you want:
+
+- :func:`add_execution_args` — add the shared scheduler/resource flag group to
+  your parser.
+- :func:`executor_from_args` — build the right executor from the parsed args.
+- :func:`clobber_from_args` — ``--resume`` → ``ClobberPolicy``.
+- :func:`report_results` — print a run summary and return a
+  :class:`ResultSummary`.
+- :func:`execute` — the thin dispatch that ties the above together and handles
+  local / scheduler / packed submission in one call.
+
+Drop to the factories whenever you want the scheduler switch explicit in your
+own code; reach for :func:`execute` when you just want it handled.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from batch.controller import BatchController
+from batch.executors import Executor
+from batch.executors.local import ParallelExecutor
+from batch.executors.pbs import PBSExecutor, PBSResources
+from batch.executors.slurm import SLURMExecutor, SLURMResources
+from batch.job import ClobberPolicy, Job, JobResult
+from batch.packed import PackedResources, submit_packed
+from batch.sweep import parse_shard_spec, shard_jobs
+
+logger = logging.getLogger(__name__)
+
+SCHEDULERS = ["local", "pbs", "slurm", "pbs-packed", "slurm-packed"]
+
+
+def add_execution_args(parser: argparse.ArgumentParser, *, packed: bool = True) -> None:
+    """Add the shared execution/scheduler flag group to *parser*.
+
+    The parser stays yours — add your project-specific flags to it before or
+    after calling this.  The added flags are consumed by
+    :func:`executor_from_args`, :func:`clobber_from_args`, and :func:`execute`.
+
+    Parameters
+    ----------
+    parser:
+        The argument parser to extend.
+    packed:
+        When True (default), also add the packing flags (``--nodes``,
+        ``--node-cpus``, ``--shard``, ``--pin-cpus``).  Set False for a driver
+        that never packs.
+
+    Flags added
+    -----------
+    ``--scheduler`` (local/pbs/slurm/pbs-packed/slurm-packed), ``--setup-only``,
+    ``--resume``, ``--max-workers`` (``$BATCH_MAX_JOBS`` or 4),
+    ``--omp-num-threads`` (``$OMP_NUM_THREADS`` or 1), ``--account``
+    (``$PBS_ACCOUNT``), ``--queue``, ``--walltime``, ``--modules``
+    (``$BATCH_MODULES``), and — with ``packed=True`` — ``--nodes``,
+    ``--node-cpus``, ``--shard`` (``I/N``), ``--pin-cpus``.
+    """
+    g = parser.add_argument_group("execution")
+    g.add_argument(
+        "--scheduler",
+        choices=SCHEDULERS,
+        default="local",
+        help="Execution backend (default: local).",
+    )
+    g.add_argument(
+        "--setup-only",
+        action="store_true",
+        help="Write .data files (local) or submission scripts (scheduler) "
+        "without running or submitting anything.",
+    )
+    g.add_argument(
+        "--resume",
+        action="store_true",
+        help="Skip jobs whose output directory already exists.",
+    )
+    g.add_argument(
+        "--max-workers",
+        type=int,
+        default=int(os.environ.get("BATCH_MAX_JOBS", 4)),
+        help="Local only: max concurrent jobs (default: $BATCH_MAX_JOBS or 4).",
+    )
+    g.add_argument(
+        "--omp-num-threads",
+        type=int,
+        default=int(os.environ.get("OMP_NUM_THREADS", 1)),
+        help="OpenMP threads per job (default: $OMP_NUM_THREADS or 1). On a "
+        "scheduler this also sets the per-job core request.",
+    )
+    g.add_argument(
+        "--account",
+        default=os.environ.get("PBS_ACCOUNT", ""),
+        help="Scheduler allocation/project code (default: $PBS_ACCOUNT).",
+    )
+    g.add_argument(
+        "--queue",
+        default="main",
+        help="Scheduler queue / partition name (default: main).",
+    )
+    g.add_argument(
+        "--walltime",
+        default="12:00:00",
+        help="Scheduler walltime limit HH:MM:SS (default: 12:00:00).",
+    )
+    g.add_argument(
+        "--modules",
+        nargs="*",
+        default=os.environ.get("BATCH_MODULES", "").split(),
+        help="Modules to 'module load' in the job script "
+        "(default: $BATCH_MODULES, space-separated).",
+    )
+    if packed:
+        p = parser.add_argument_group("packing (pbs-packed / slurm-packed)")
+        p.add_argument(
+            "--nodes",
+            type=int,
+            default=1,
+            help="Packed only: number of exclusive nodes to fan over (default: 1).",
+        )
+        p.add_argument(
+            "--node-cpus",
+            type=int,
+            default=128,
+            help="Packed / local pinning: cores per node (default: 128).",
+        )
+        p.add_argument(
+            "--shard",
+            default="",
+            metavar="I/N",
+            help="Run only shard I of N of the job list (round-robin). "
+            "Packed wrappers set this per node.",
+        )
+        p.add_argument(
+            "--pin-cpus",
+            action="store_true",
+            help="Local only: pin each concurrent job to a disjoint core range "
+            "(numactl). Needed when packing jobs on a node.",
+        )
+
+
+def clobber_from_args(args: argparse.Namespace) -> ClobberPolicy:
+    """Map ``--resume`` to a :class:`ClobberPolicy`.
+
+    ``SKIP`` when resuming (skip finished job dirs), else ``OVERWRITE``.
+    """
+    return ClobberPolicy.SKIP if args.resume else ClobberPolicy.OVERWRITE
+
+
+def executor_from_args(
+    args: argparse.Namespace, *, env: dict[str, str] | None = None
+) -> Executor:
+    """Build the executor selected by ``--scheduler``.
+
+    Handles the three *executor* backends — ``local``, ``pbs``, ``slurm``.  The
+    ``*-packed`` schedulers do **not** map to an executor (packing submits
+    wrapper jobs, it is not a per-job backend); use :func:`execute` or
+    :func:`batch.submit_packed` for those.
+
+    Parameters
+    ----------
+    args:
+        Parsed args carrying the flags from :func:`add_execution_args`.
+    env:
+        Extra environment variables merged into each job's environment, on top
+        of the ``OMP_NUM_THREADS`` derived from ``--omp-num-threads``.
+
+    Returns
+    -------
+    Executor
+        A ``ParallelExecutor``, ``PBSExecutor``, or ``SLURMExecutor``.
+
+    Raises
+    ------
+    ValueError
+        If ``--scheduler`` is a ``*-packed`` value or otherwise unsupported here.
+    """
+    run_env = {"OMP_NUM_THREADS": str(args.omp_num_threads)}
+    if env:
+        run_env.update(env)
+    threads = args.omp_num_threads
+
+    if args.scheduler == "local":
+        pin = getattr(args, "pin_cpus", False)
+        return ParallelExecutor(
+            max_workers=args.max_workers,
+            env=run_env,
+            cpu_affinity=pin,
+            total_cpus=getattr(args, "node_cpus", None) if pin else None,
+        )
+    if args.scheduler == "pbs":
+        return PBSExecutor(
+            default_resources=PBSResources(
+                queue=args.queue,
+                nodes=1,
+                ncpus=threads,
+                mpiprocs=1,
+                ompthreads=threads,
+                walltime=args.walltime,
+                account=args.account,
+                env_vars=run_env,
+                modules=args.modules,
+            ),
+            dry_run=args.setup_only,
+        )
+    if args.scheduler == "slurm":
+        return SLURMExecutor(
+            default_resources=SLURMResources(
+                partition=args.queue,
+                nodes=1,
+                ntasks_per_node=1,
+                cpus_per_task=threads,
+                time=args.walltime,
+                account=args.account,
+                env_vars=run_env,
+                modules=args.modules,
+            ),
+            dry_run=args.setup_only,
+        )
+    raise ValueError(
+        f"executor_from_args does not handle --scheduler={args.scheduler!r}; "
+        "packed schedulers submit wrappers via execute()/submit_packed()."
+    )
+
+
+@dataclass
+class ResultSummary:
+    """Aggregate outcome of a batch run.
+
+    ``n_ok`` + ``n_failed`` + ``n_pending`` == ``n_total``.  Pending jobs are
+    scheduler submissions whose result is not yet known (``run(wait=False)``).
+    """
+
+    n_total: int
+    n_ok: int
+    n_failed: int
+    n_pending: int
+    failures: list[JobResult] = field(default_factory=list)
+
+
+def report_results(results: list[JobResult], *, echo: bool = True) -> ResultSummary:
+    """Summarize *results*; when *echo*, print the summary and any failures.
+
+    Returns the :class:`ResultSummary` so callers can act on it without parsing
+    stdout.  When every result is still pending (a submit-and-exit scheduler
+    run), the printed form reports what was *submitted* rather than a
+    success/failure tally.
+    """
+    n_ok = sum(1 for r in results if r.success)
+    n_pending = sum(1 for r in results if r.pending)
+    failures = [r for r in results if not r.success and not r.pending]
+    summary = ResultSummary(
+        n_total=len(results),
+        n_ok=n_ok,
+        n_failed=len(failures),
+        n_pending=n_pending,
+        failures=failures,
+    )
+    if echo:
+        if n_pending and not n_ok and not failures:
+            print(f"Submitted {n_pending} job(s).")
+            for r in results:
+                if r.job_id:
+                    print(f"  {r.job.prefix}  ->  job {r.job_id}")
+        else:
+            print(
+                f"\nCompleted: {n_ok}/{len(results)} successful, "
+                f"{len(failures)} failed."
+            )
+            for r in failures:
+                print(f"  FAILED: {r.job.prefix}  (see {r.paths.log})")
+    return summary
+
+
+def execute(
+    args: argparse.Namespace,
+    jobs: list[Job],
+    *,
+    experiment: str = "",
+    inner_command=None,
+    env: dict[str, str] | None = None,
+    wait: bool | None = None,
+    base_path: Path | str | None = None,
+    script_dir: Path | str | None = None,
+    workdir: Path | str | None = None,
+) -> list[JobResult]:
+    """Run *jobs* according to ``--scheduler``, tying the factories together.
+
+    Dispatch:
+
+    - ``*-packed`` → build a per-node :class:`PackedResources` from the args and
+      call :func:`batch.submit_packed`.  Requires *inner_command*; returns an
+      empty list (the per-run work happens on the compute nodes).
+    - otherwise → apply ``--shard`` (if set) via :func:`shard_jobs`, build a
+      :class:`BatchController` with :func:`executor_from_args` /
+      :func:`clobber_from_args`, then ``setup()`` (``--setup-only`` + local) or
+      ``run()`` and :func:`report_results`.
+
+    Parameters
+    ----------
+    args:
+        Parsed args from a parser extended by :func:`add_execution_args`.
+    jobs:
+        The full job list.  Sharding is applied here for a ``--shard`` run.
+    experiment:
+        Experiment subdirectory for the controller.
+    inner_command:
+        ``(shard_i, n_shards) -> argv`` callable, required for a ``*-packed``
+        scheduler (the per-node re-invocation of your driver in local mode).
+    env:
+        Extra environment variables for each job (merged with ``OMP_NUM_THREADS``).
+    wait:
+        Override the blocking behavior.  Default: ``True`` for ``local``,
+        ``False`` for a scheduler (submit-and-exit).
+    base_path:
+        Root output directory passed to the controller (else ``$OUTPUT_PATH``).
+    script_dir:
+        Where packed wrappers are written (default: ``<cwd>/_pack_scripts``).
+    workdir:
+        Directory each packed wrapper ``cd``s into before its inner command.
+
+    Returns
+    -------
+    list[JobResult]
+        Per-job results for the local/scheduler paths (empty for packed and for
+        ``--setup-only`` local).
+    """
+    scheduler = args.scheduler
+
+    if scheduler.endswith("-packed"):
+        if inner_command is None:
+            raise ValueError(
+                f"--scheduler {scheduler} requires an inner_command "
+                "(the per-node re-invocation of your driver)."
+            )
+        base = scheduler.split("-")[0]
+        resources = PackedResources(
+            queue=args.queue,
+            walltime=args.walltime,
+            account=args.account,
+            node_cpus=getattr(args, "node_cpus", 128),
+            modules=args.modules,
+        )
+        sdir = (
+            Path(script_dir) if script_dir is not None else Path.cwd() / "_pack_scripts"
+        )
+        submit_packed(
+            n_nodes=getattr(args, "nodes", 1),
+            inner_command=inner_command,
+            resources=resources,
+            scheduler=base,
+            script_dir=sdir,
+            dry_run=args.setup_only,
+            workdir=workdir,
+        )
+        return []
+
+    # local / pbs / slurm
+    shard = getattr(args, "shard", "")
+    if shard:
+        i, n = parse_shard_spec(shard)
+        if n > 1:
+            jobs = shard_jobs(jobs, i, n)
+            logger.info("Shard %d/%d: running %d of %d jobs.", i, n, len(jobs), n)
+
+    ctrl = BatchController(
+        jobs=jobs,
+        executor=executor_from_args(args, env=env),
+        base_path=base_path,
+        experiment=experiment,
+        clobber=clobber_from_args(args),
+    )
+
+    if args.setup_only and scheduler == "local":
+        paths = ctrl.setup()
+        logger.info("Setup complete for %d job(s).", len(paths))
+        return []
+
+    if wait is None:
+        wait = scheduler == "local"
+    results = ctrl.run(wait=wait)
+    report_results(results)
+    return results

--- a/batch/cli.py
+++ b/batch/cli.py
@@ -63,7 +63,7 @@ def add_execution_args(parser: argparse.ArgumentParser, *, packed: bool = True) 
     ``--scheduler`` (local/pbs/slurm/pbs-packed/slurm-packed), ``--setup-only``,
     ``--resume``, ``--max-workers`` (``$BATCH_MAX_JOBS`` or 4),
     ``--omp-num-threads`` (``$OMP_NUM_THREADS`` or 1), ``--account``
-    (``$PBS_ACCOUNT``), ``--queue``, ``--walltime``, ``--modules``
+    (``$BATCH_ACCOUNT``), ``--queue``, ``--walltime``, ``--modules``
     (``$BATCH_MODULES``), and — with ``packed=True`` — ``--nodes``,
     ``--node-cpus``, ``--shard`` (``I/N``), ``--pin-cpus``.
     """
@@ -100,8 +100,9 @@ def add_execution_args(parser: argparse.ArgumentParser, *, packed: bool = True) 
     )
     g.add_argument(
         "--account",
-        default=os.environ.get("PBS_ACCOUNT", ""),
-        help="Scheduler allocation/project code (default: $PBS_ACCOUNT).",
+        default=os.environ.get("BATCH_ACCOUNT", ""),
+        help="Scheduler allocation/project code, PBS or SLURM alike "
+        "(default: $BATCH_ACCOUNT).",
     )
     g.add_argument(
         "--queue",

--- a/batch/sweep.py
+++ b/batch/sweep.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import itertools
-from typing import Any, Callable
+from typing import Any, Callable, TypeVar
 
 from batch.job import Job
+
+_J = TypeVar("_J", bound=Job)
 
 
 def product_sweep(
@@ -152,7 +154,7 @@ def parse_shard_spec(spec: str) -> tuple[int, int]:
     return i, n
 
 
-def shard_jobs(jobs: list[Job], i: int, n: int) -> list[Job]:
+def shard_jobs(jobs: list[_J], i: int, n: int) -> list[_J]:
     """Return shard *i* of *n* from *jobs*, round-robin (1-based).
 
     Splitting the job list this way lets each of *n* nodes run a disjoint slice

--- a/docs/postprocessing.md
+++ b/docs/postprocessing.md
@@ -79,6 +79,11 @@ batch, not in `post_run`. Use the `results` list from `ctrl.run(wait=True)`:
 filter to the successful jobs and iterate to load output files, compute metrics,
 or produce comparison plots spanning the whole ensemble.
 
+For a quick pass/fail tally first, `batch.report_results(results)` prints a
+`Completed: X/Y successful, Z failed` summary (with the log path of each failure)
+and returns a `ResultSummary` you can branch on — see
+[Driving a batch from the command line](running-on-hpc.md#driving-a-batch-from-the-command-line).
+
 ```python
 import matplotlib.pyplot as plt
 import numpy as np

--- a/docs/running-on-hpc.md
+++ b/docs/running-on-hpc.md
@@ -208,6 +208,58 @@ the jobs finish. `shard_jobs(jobs, i, n)` and `parse_shard_spec("i/n")` (both in
 
 ---
 
+## Driving a batch from the command line
+
+Every scheduler driver ends up re-implementing the same `--scheduler` /
+`--account` / `--resume` / `--max-workers` argparse block and the same
+arg→executor glue. `batch.cli` factors that out **without** owning your `main()`:
+you keep your own parser and job list, and add only your domain flags.
+
+```python
+import argparse, sys
+from batch import add_execution_args, execute
+
+parser = argparse.ArgumentParser()
+add_execution_args(parser)                       # shared scheduler/resource flags
+parser.add_argument("--storms-path", ...)        # your domain flags
+args = parser.parse_args()
+
+jobs = make_jobs(args)                            # you build the job list
+
+def inner(i, n):                                  # only needed for *-packed
+    return [sys.executable, __file__, "--scheduler", "local",
+            "--shard", f"{i}/{n}", "--pin-cpus"]
+
+results = execute(args, jobs, experiment="storm_ensemble", inner_command=inner)
+```
+
+`execute` dispatches on `--scheduler`:
+
+- `local` → `ParallelExecutor` (blocks); `--setup-only` writes `.data` only.
+- `pbs` / `slurm` → the scheduler executor, submit-and-exit (`wait=False`);
+  `--setup-only` writes the submission scripts without submitting.
+- `pbs-packed` / `slurm-packed` → `submit_packed` with the per-node
+  `inner_command` (required); `--nodes` / `--node-cpus` size the packing, and the
+  re-invoked local shard is selected by `--shard`.
+
+Prefer the switch explicit in your own code? Skip `execute` and use the factories
+directly — they are what `execute` is built from:
+
+```python
+from batch import (BatchController, executor_from_args, clobber_from_args,
+                   report_results)
+
+ctrl = BatchController(jobs, executor_from_args(args),
+                       experiment="storm_ensemble", clobber=clobber_from_args(args))
+report_results(ctrl.run(wait=args.scheduler == "local"))
+```
+
+`report_results` prints a `Completed: X/Y successful, Z failed` summary (or, for a
+submit-and-exit run, the submitted job IDs) and returns a `ResultSummary`
+(`n_ok` / `n_failed` / `n_pending` / `failures`) so you can branch on the outcome.
+
+---
+
 ## Per-job resource overrides (no subclassing)
 
 Both executors read resources with `getattr(job, "<name>", default_resources)`,

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -8,13 +8,22 @@ Common failure modes and how to resolve them.
 
 ## Environment variables
 
-`batch` reads three environment variables:
+`batch` reads these environment variables:
 
 | Variable | Effect |
 |---|---|
 | `OUTPUT_PATH` | Base directory for all job output. Defaults to the current working directory. Overridden by an explicit `base_path=` on `BatchController`. |
 | `BATCH_MAX_JOBS` | Default `max_workers` for `ParallelExecutor`. Defaults to 4. |
 | `OMP_NUM_THREADS` | Threads each OpenMP solver process uses. Set it via the executor's `env=` (local) or `env_vars=` (scheduler). |
+
+The `batch.cli` helpers add three more, used only as defaults for their
+matching flags (any of which you can still pass explicitly):
+
+| Variable | Flag default |
+|---|---|
+| `BATCH_ACCOUNT` | `--account` — scheduler allocation/project code (PBS or SLURM). |
+| `BATCH_MODULES` | `--modules` — space-separated modules to `module load`. |
+| `BATCH_MAX_JOBS` | `--max-workers` (as above). |
 
 ---
 

--- a/examples/derecho_ensemble/pbs_batch.py
+++ b/examples/derecho_ensemble/pbs_batch.py
@@ -24,9 +24,9 @@ Directory layout produced::
 
 Usage
 -----
-Dry run (write qsub scripts, do not submit — needs no scheduler)::
+Write qsub scripts without submitting (needs no scheduler)::
 
-    python pbs_batch.py --dry-run
+    python pbs_batch.py --setup-only
 
 Submit to Derecho::
 
@@ -47,13 +47,7 @@ import importlib.util
 import logging
 from pathlib import Path
 
-from batch import (
-    BatchController,
-    ClobberPolicy,
-    Job,
-    PBSExecutor,
-    PBSResources,
-)
+from batch import Job, PBSResources, add_execution_args, execute
 
 logging.basicConfig(
     level=logging.INFO,
@@ -153,21 +147,10 @@ def make_jobs(storms_path: Path, setrun_path: Path, account: str) -> list[StormJ
 
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument(
-        "--dry-run",
-        action="store_true",
-        help="Write qsub scripts but do not call qsub.",
-    )
-    parser.add_argument(
-        "--resume",
-        action="store_true",
-        help="Skip jobs whose output directory already exists.",
-    )
-    parser.add_argument(
-        "--account",
-        default="",
-        help="Derecho project code (#PBS -A). Required to actually submit.",
-    )
+    # Shared execution flags; default this driver to PBS. Each StormJob carries
+    # its own PBSResources (with plot=True), which override the executor default.
+    add_execution_args(parser, packed=False)
+    parser.set_defaults(scheduler="pbs")
     parser.add_argument(
         "--storms-path",
         type=Path,
@@ -188,35 +171,9 @@ def main() -> None:
         account=args.account,
     )
 
-    executor = PBSExecutor(
-        default_resources=PBSResources(
-            queue="main",
-            nodes=1,
-            ncpus=128,
-            mpiprocs=1,
-            ompthreads=128,
-            walltime="12:00:00",
-            account=args.account,
-        ),
-        dry_run=args.dry_run,
-    )
-
-    ctrl = BatchController(
-        jobs=jobs,
-        executor=executor,
-        experiment="derecho_storm_ensemble",
-        clobber=ClobberPolicy.SKIP if args.resume else ClobberPolicy.OVERWRITE,
-    )
-
-    # For PBS we do not wait — qsub returns immediately after submission.
-    results = ctrl.run(wait=False)
-
-    if args.dry_run:
-        print(f"Dry run: {len(results)} script(s) written, none submitted.")
-    else:
-        print(f"Submitted {len(results)} job(s) to PBS.")
-        for r in results:
-            print(f"  {r.job.prefix}  ->  PBS job {r.job_id}")
+    # execute() submits and returns immediately for PBS (wait=False), printing
+    # the submitted job IDs via report_results.
+    execute(args, jobs, experiment="derecho_storm_ensemble")
 
 
 if __name__ == "__main__":

--- a/examples/local_ensemble/run_batch.py
+++ b/examples/local_ensemble/run_batch.py
@@ -28,7 +28,6 @@ from __future__ import annotations
 
 import argparse
 import logging
-import os
 from pathlib import Path
 
 # Use non-interactive backend so plotting works in batch without a display
@@ -38,7 +37,7 @@ matplotlib.use("Agg")
 
 from manning_job import ManningJob
 
-from batch import BatchController, ClobberPolicy, ParallelExecutor
+from batch import add_execution_args, execute
 from batch.sweep import product_sweep
 
 logging.basicConfig(
@@ -103,52 +102,18 @@ def plot_ensemble(results: list) -> None:
 
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument(
-        "--setup-only",
-        action="store_true",
-        help="Write .data files only; do not run the solver.",
-    )
-    parser.add_argument(
-        "--resume",
-        action="store_true",
-        help="Skip jobs whose output directory already exists.",
-    )
-    parser.add_argument(
-        "--max-workers",
-        type=int,
-        default=int(os.environ.get("BATCH_MAX_JOBS", 4)),
-        help="Maximum concurrent jobs (default: $BATCH_MAX_JOBS or 4).",
-    )
+    # Shared execution flags (--scheduler/--resume/--max-workers/…). This example
+    # is local-only, so the packing flags are omitted (packed=False); pass a
+    # scheduler flag to reuse the same driver on a cluster.
+    add_execution_args(parser, packed=False)
     args = parser.parse_args()
 
-    jobs = make_jobs()
+    # execute() blocks for the local scheduler, prints the run summary via
+    # report_results, and returns the results ([] under --setup-only).
+    results = execute(args, make_jobs(), experiment="manning_sensitivity")
 
-    clobber = ClobberPolicy.SKIP if args.resume else ClobberPolicy.OVERWRITE
-
-    ctrl = BatchController(
-        jobs=jobs,
-        executor=ParallelExecutor(max_workers=args.max_workers),
-        experiment="manning_sensitivity",
-        clobber=clobber,
-    )
-
-    if args.setup_only:
-        paths = ctrl.setup()
-        print(f"Setup complete for {len(paths)} job(s).")
-        return
-
-    results = ctrl.run(wait=True)
-
-    n_ok = sum(1 for r in results if r.success)
-    n_fail = sum(1 for r in results if not r.success and r.returncode is not None)
-    print(f"\nCompleted: {n_ok}/{len(results)} successful, {n_fail} failed.")
-
-    if n_fail:
-        for r in results:
-            if r.returncode is not None and r.returncode != 0:
-                print(f"  FAILED: {r.job.prefix}  (see {r.paths.log})")
-
-    plot_ensemble(results)
+    if not args.setup_only:
+        plot_ensemble(results)
 
 
 if __name__ == "__main__":

--- a/examples/storm_surge/storm_batch.py
+++ b/examples/storm_surge/storm_batch.py
@@ -21,9 +21,9 @@ Directory layout produced::
 
 Usage
 -----
-Dry run (inspect generated scripts without submitting)::
+Inspect generated scripts without submitting::
 
-    python run_batch.py --dry-run
+    python run_batch.py --setup-only
 
 Submit to SLURM::
 
@@ -41,13 +41,7 @@ import importlib.util
 import logging
 from pathlib import Path
 
-from batch import (
-    BatchController,
-    ClobberPolicy,
-    Job,
-    SLURMExecutor,
-    SLURMResources,
-)
+from batch import Job, SLURMResources, add_execution_args, execute
 
 logging.basicConfig(
     level=logging.INFO,
@@ -84,6 +78,7 @@ class StormJob(Job):
         storms_path: Path = Path("."),
         setrun_path: Path | None = None,
         cpus: int = 8,
+        account: str = "",
     ) -> None:
         super().__init__()
 
@@ -112,7 +107,7 @@ class StormJob(Job):
             ntasks_per_node=1,
             cpus_per_task=cpus,
             time="06:00:00",
-            account="",  # fill in your allocation
+            account=account,
             env_vars={"OMP_NUM_THREADS": str(cpus)},
             modules=["ncarenv/23.09", "python/3.11.4"],
         )
@@ -126,13 +121,14 @@ class StormJob(Job):
 # ---------------------------------------------------------------------------
 
 
-def make_jobs(storms_path: Path, setrun_path: Path) -> list[StormJob]:
+def make_jobs(storms_path: Path, setrun_path: Path, account: str) -> list[StormJob]:
     """Build jobs for storms 1–100."""
     return [
         StormJob(
             storm_num=n,
             storms_path=storms_path,
             setrun_path=setrun_path,
+            account=account,
         )
         for n in range(1, 101)
     ]
@@ -140,16 +136,10 @@ def make_jobs(storms_path: Path, setrun_path: Path) -> list[StormJob]:
 
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument(
-        "--dry-run",
-        action="store_true",
-        help="Write submission scripts but do not call sbatch.",
-    )
-    parser.add_argument(
-        "--resume",
-        action="store_true",
-        help="Skip jobs whose output directory already exists.",
-    )
+    # Shared execution flags; default this driver to SLURM. Each StormJob still
+    # carries its own SLURMResources, which override the executor default.
+    add_execution_args(parser, packed=False)
+    parser.set_defaults(scheduler="slurm")
     parser.add_argument(
         "--storms-path",
         type=Path,
@@ -164,34 +154,15 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    jobs = make_jobs(storms_path=args.storms_path, setrun_path=args.setrun)
-
-    executor = SLURMExecutor(
-        default_resources=SLURMResources(
-            partition="main",
-            nodes=1,
-            cpus_per_task=8,
-            time="06:00:00",
-        ),
-        dry_run=args.dry_run,
+    jobs = make_jobs(
+        storms_path=args.storms_path,
+        setrun_path=args.setrun,
+        account=args.account,
     )
 
-    ctrl = BatchController(
-        jobs=jobs,
-        executor=executor,
-        experiment="storm_ensemble",
-        clobber=ClobberPolicy.SKIP if args.resume else ClobberPolicy.OVERWRITE,
-    )
-
-    # For SLURM we do not wait — sbatch returns immediately
-    results = ctrl.run(wait=False)
-
-    if args.dry_run:
-        print(f"Dry run: {len(results)} script(s) written, none submitted.")
-    else:
-        print(f"Submitted {len(results)} job(s) to SLURM.")
-        for r in results:
-            print(f"  {r.job.prefix}  →  SLURM job {r.job_id}")
+    # execute() submits and returns immediately for a scheduler (wait=False),
+    # printing the submitted job IDs via report_results.
+    execute(args, jobs, experiment="storm_ensemble")
 
 
 if __name__ == "__main__":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,297 @@
+"""Tests for batch.cli.
+
+All tests avoid a real scheduler and solver: executor construction is checked by
+type, packed dispatch is patched, and execute() is driven through the
+dry_run / setup-only paths so nothing is actually submitted or run.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from batch.cli import (
+    ResultSummary,
+    add_execution_args,
+    clobber_from_args,
+    execute,
+    executor_from_args,
+    report_results,
+)
+from batch.executors.local import ParallelExecutor
+from batch.executors.pbs import PBSExecutor
+from batch.executors.slurm import SLURMExecutor
+from batch.job import ClobberPolicy, JobPaths, JobResult
+from tests.conftest import MockJob
+
+
+def parse(argv, *, packed=True) -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    add_execution_args(parser, packed=packed)
+    return parser.parse_args(argv)
+
+
+def make_result(prefix, returncode, job_id=None, tmp_path=None) -> JobResult:
+    job = MockJob(prefix=prefix)
+    base = tmp_path or Path("/tmp")
+    paths = JobPaths(
+        job=base / prefix, plots=base / prefix / "plots", log=base / prefix / "log.txt"
+    )
+    return JobResult(job=job, paths=paths, returncode=returncode, job_id=job_id)
+
+
+# ---------------------------------------------------------------------------
+# add_execution_args
+# ---------------------------------------------------------------------------
+
+
+class TestAddExecutionArgs:
+    def test_defaults(self):
+        args = parse([])
+        assert args.scheduler == "local"
+        assert args.resume is False
+        assert args.setup_only is False
+        assert args.max_workers >= 1
+        assert args.queue == "main"
+
+    def test_overrides(self):
+        args = parse(
+            [
+                "--scheduler",
+                "pbs",
+                "--resume",
+                "--account",
+                "NCAR0001",
+                "--walltime",
+                "06:00:00",
+                "--omp-num-threads",
+                "16",
+                "--modules",
+                "ncarenv",
+                "conda",
+            ]
+        )
+        assert args.scheduler == "pbs"
+        assert args.resume is True
+        assert args.account == "NCAR0001"
+        assert args.walltime == "06:00:00"
+        assert args.omp_num_threads == 16
+        assert args.modules == ["ncarenv", "conda"]
+
+    def test_packed_flags_present(self):
+        args = parse(
+            ["--nodes", "4", "--node-cpus", "128", "--shard", "2/4", "--pin-cpus"]
+        )
+        assert args.nodes == 4
+        assert args.node_cpus == 128
+        assert args.shard == "2/4"
+        assert args.pin_cpus is True
+
+    def test_packed_flags_absent_when_disabled(self):
+        parser = argparse.ArgumentParser()
+        add_execution_args(parser, packed=False)
+        with pytest.raises(SystemExit):
+            parser.parse_args(["--nodes", "4"])
+
+    def test_project_can_add_own_flags(self):
+        parser = argparse.ArgumentParser()
+        add_execution_args(parser)
+        parser.add_argument("--storms-path")
+        args = parser.parse_args(["--storms-path", "/data", "--scheduler", "slurm"])
+        assert args.storms_path == "/data"
+        assert args.scheduler == "slurm"
+
+
+# ---------------------------------------------------------------------------
+# clobber_from_args
+# ---------------------------------------------------------------------------
+
+
+class TestClobberFromArgs:
+    def test_resume_gives_skip(self):
+        assert clobber_from_args(parse(["--resume"])) is ClobberPolicy.SKIP
+
+    def test_no_resume_gives_overwrite(self):
+        assert clobber_from_args(parse([])) is ClobberPolicy.OVERWRITE
+
+
+# ---------------------------------------------------------------------------
+# executor_from_args
+# ---------------------------------------------------------------------------
+
+
+class TestExecutorFromArgs:
+    def test_local_returns_parallel_executor(self):
+        ex = executor_from_args(parse(["--scheduler", "local", "--max-workers", "3"]))
+        assert isinstance(ex, ParallelExecutor)
+        assert ex.max_workers == 3
+        assert ex.cpu_affinity is False
+
+    def test_local_pin_cpus_enables_affinity(self):
+        ex = executor_from_args(
+            parse(
+                [
+                    "--scheduler",
+                    "local",
+                    "--max-workers",
+                    "4",
+                    "--pin-cpus",
+                    "--node-cpus",
+                    "128",
+                ]
+            )
+        )
+        assert ex.cpu_affinity is True
+        assert ex.total_cpus == 128
+
+    def test_omp_threads_in_env(self):
+        ex = executor_from_args(
+            parse(["--scheduler", "local", "--omp-num-threads", "8"])
+        )
+        assert ex.env["OMP_NUM_THREADS"] == "8"
+
+    def test_extra_env_merged(self):
+        ex = executor_from_args(parse(["--scheduler", "local"]), env={"FOO": "bar"})
+        assert ex.env["FOO"] == "bar"
+        assert "OMP_NUM_THREADS" in ex.env
+
+    def test_pbs_returns_pbs_executor_with_threads(self):
+        ex = executor_from_args(
+            parse(["--scheduler", "pbs", "--omp-num-threads", "64"])
+        )
+        assert isinstance(ex, PBSExecutor)
+        assert ex.default_resources.ompthreads == 64
+        assert ex.default_resources.ncpus == 64
+
+    def test_setup_only_sets_scheduler_dry_run(self):
+        ex = executor_from_args(parse(["--scheduler", "pbs", "--setup-only"]))
+        assert ex.dry_run is True
+
+    def test_slurm_returns_slurm_executor(self):
+        ex = executor_from_args(parse(["--scheduler", "slurm", "--queue", "gpu"]))
+        assert isinstance(ex, SLURMExecutor)
+        assert ex.default_resources.partition == "gpu"
+
+    def test_packed_scheduler_raises(self):
+        with pytest.raises(ValueError, match="packed"):
+            executor_from_args(parse(["--scheduler", "pbs-packed"]))
+
+
+# ---------------------------------------------------------------------------
+# report_results
+# ---------------------------------------------------------------------------
+
+
+class TestReportResults:
+    def test_counts(self):
+        results = [
+            make_result("a", 0),
+            make_result("b", 1),
+            make_result("c", 0),
+            make_result("d", None, job_id="123"),
+        ]
+        summary = report_results(results, echo=False)
+        assert summary == ResultSummary(
+            n_total=4,
+            n_ok=2,
+            n_failed=1,
+            n_pending=1,
+            failures=summary.failures,
+        )
+        assert [r.job.prefix for r in summary.failures] == ["b"]
+
+    def test_all_pending_reports_submitted(self, capsys):
+        results = [
+            make_result("a", None, job_id="1"),
+            make_result("b", None, job_id="2"),
+        ]
+        summary = report_results(results, echo=True)
+        assert summary.n_pending == 2
+        out = capsys.readouterr().out
+        assert "Submitted 2 job(s)" in out
+        assert "job 1" in out and "job 2" in out
+
+    def test_failures_printed(self, capsys, tmp_path):
+        report_results([make_result("boom", 1, tmp_path=tmp_path)], echo=True)
+        out = capsys.readouterr().out
+        assert "FAILED: boom" in out
+
+
+# ---------------------------------------------------------------------------
+# execute
+# ---------------------------------------------------------------------------
+
+
+class TestExecute:
+    def test_packed_requires_inner_command(self):
+        with pytest.raises(ValueError, match="inner_command"):
+            execute(parse(["--scheduler", "pbs-packed"]), [], experiment="e")
+
+    def test_packed_dispatches_to_submit_packed(self, tmp_path):
+        args = parse(["--scheduler", "pbs-packed", "--nodes", "3", "--setup-only"])
+        inner = lambda i, n: ["python", "d.py", "--shard", f"{i}/{n}"]  # noqa: E731
+        with patch("batch.cli.submit_packed") as mock_sp:
+            out = execute(
+                args, [], experiment="e", inner_command=inner, script_dir=tmp_path
+            )
+        assert out == []
+        mock_sp.assert_called_once()
+        kwargs = mock_sp.call_args.kwargs
+        assert kwargs["n_nodes"] == 3
+        assert kwargs["scheduler"] == "pbs"
+        assert kwargs["dry_run"] is True
+
+    def test_slurm_packed_maps_to_slurm(self, tmp_path):
+        args = parse(["--scheduler", "slurm-packed", "--nodes", "2"])
+        with patch("batch.cli.submit_packed") as mock_sp:
+            execute(
+                args,
+                [],
+                experiment="e",
+                inner_command=lambda i, n: ["x"],
+                script_dir=tmp_path,
+            )
+        assert mock_sp.call_args.kwargs["scheduler"] == "slurm"
+
+    def test_local_setup_only_writes_data_and_returns_empty(self, tmp_path):
+        jobs = [MockJob(prefix=f"j{i}") for i in range(3)]
+        out = execute(
+            parse(["--scheduler", "local", "--setup-only"]),
+            jobs,
+            experiment="exp",
+            base_path=tmp_path,
+        )
+        assert out == []
+        # setup() wrote each job's directory + data file.
+        for i in range(3):
+            assert (tmp_path / "exp" / f"j{i}" / "claw.data").exists()
+
+    def test_local_setup_only_honors_shard(self, tmp_path):
+        jobs = [MockJob(prefix=f"j{i}") for i in range(4)]
+        execute(
+            parse(["--scheduler", "local", "--setup-only", "--shard", "1/2"]),
+            jobs,
+            experiment="exp",
+            base_path=tmp_path,
+        )
+        # Shard 1/2 of [j0,j1,j2,j3] is [j0, j2].
+        exp = tmp_path / "exp"
+        assert (exp / "j0").exists() and (exp / "j2").exists()
+        assert not (exp / "j1").exists() and not (exp / "j3").exists()
+
+    def test_pbs_setup_only_writes_scripts(self, tmp_path):
+        jobs = [MockJob(prefix=f"j{i}") for i in range(2)]
+        out = execute(
+            parse(["--scheduler", "pbs", "--setup-only"]),
+            jobs,
+            experiment="exp",
+            base_path=tmp_path,
+        )
+        # dry_run executor: one pending result + a submission script per job.
+        assert len(out) == 2
+        assert all(r.pending for r in out)
+        for i in range(2):
+            assert (tmp_path / "exp" / f"j{i}" / "j{}_run.sh".format(i)).exists()


### PR DESCRIPTION
## What

Adds `batch.cli`, a layered command-line surface so driver scripts stop
copy-pasting the scheduler/resource argparse block and the arg→object glue.
Builds on `batch.packed` (#8) for the packed dispatch.

The duplication was real and already drifting: `ClobberPolicy.SKIP if resume else
OVERWRITE`, the `--max-workers`/`--account`/`--resume` flag block, and the
success/failure print loop were repeated verbatim across all three shipped
examples (and the ETC driver).

## API (layered — use as much or as little as you want)

- **`add_execution_args(parser, *, packed=True)`** — contributes the shared flag
  group (`--scheduler`, `--setup-only`, `--resume`, `--max-workers`,
  `--omp-num-threads`, `--account`, `--queue`, `--walltime`, `--modules`, and the
  packing flags). The parser stays yours; add domain flags to it.
- **`executor_from_args(args, *, env=None)`** — builds the `local` / `pbs` /
  `slurm` executor (packed schedulers raise — they submit wrappers, not per-job).
- **`clobber_from_args(args)`** — `--resume` → `ClobberPolicy`.
- **`report_results(results, *, echo=True) → ResultSummary`** — summary + failure
  log paths, or submitted job IDs for a submit-and-exit run.
- **`execute(args, jobs, *, experiment, inner_command=None, …)`** — the thin
  dispatch tying the above together (local blocks; scheduler submit-and-exit;
  `*-packed` calls `submit_packed`; `--shard` restricts the local job list).
  `main()` stays linear: parse → build jobs → execute → post-process.

Also makes `batch.sweep.shard_jobs` generic so it preserves the concrete `Job`
subtype (clears the type-checker invariance warnings).

## Examples

All three shipped drivers were rewritten onto the new helpers and shrank
noticeably (net −26 lines across the examples despite added comments), which is
the point — that's the boilerplate that no longer needs copying.                                                                   

## Tests

`tests/test_cli.py`: arg defaults/overrides, `packed=False` omits packing flags,
executor type per `--scheduler` (+ `--pin-cpus` → affinity, `--setup-only` →
dry_run), clobber mapping, `report_results` counts + "Submitted" wording, and
`execute` across packed (patched), local setup-only (+ `--shard`), and pbs
dry-run paths. No real scheduler or solver needed.

Full suite: 198 passed; `ruff check` + `ruff format` clean. No new dependencies.

## Follow-up

Adopting this in the ETC `run_tests.py` (collapsing its argparse + executor
construction + `report_results`) is a separate change in that repo.
