### PR TITLE
Implement batch.analysis: timing parser + performance plots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### Added
+- `batch.analysis`: `parse_timing(job_dir)` reads a GeoClaw run's `timing.txt`
+  into a structured dict (per-level, per-component, and total wall/cpu, plus the
+  OpenMP thread count); `plot_performance(job_dirs, labels, out_path)` builds a
+  three-panel wall-time / CPU-efficiency comparison across runs.  `parse_timing`
+  is standard-library only; `plot_performance` needs the optional `[analysis]`
+  extra (matplotlib + numpy) and degrades gracefully when it is absent.
+  Replaces the `NotImplementedError` stub.
 - `batch.cli`: shared command-line surface for driver scripts, so projects stop
   copy-pasting the scheduler/resource argparse block and the arg→executor glue.
   `add_execution_args(parser)` contributes the generic flag group;

--- a/batch/__init__.py
+++ b/batch/__init__.py
@@ -10,9 +10,11 @@ The most commonly used names are re-exported here for convenience::
     from batch import PBSExecutor, PBSResources
     from batch import PackedResources, submit_packed
     from batch import add_execution_args, executor_from_args, execute, report_results
+    from batch import parse_timing, plot_performance
     from batch.sweep import product_sweep, zip_sweep, shard_jobs
 """
 
+from batch.analysis import parse_timing, plot_performance
 from batch.cli import (
     ResultSummary,
     add_execution_args,
@@ -54,4 +56,6 @@ __all__ = [
     "execute",
     "report_results",
     "ResultSummary",
+    "parse_timing",
+    "plot_performance",
 ]

--- a/batch/analysis.py
+++ b/batch/analysis.py
@@ -1,3 +1,249 @@
-"""Analysis Tools for Batch"""
+"""Cross-run analysis for GeoClaw batches.
 
-raise NotImplementedError("This module is not yet implemented.")
+Two pieces, both driven off each job's on-disk output so they work whether the
+runs happened locally or on a scheduler:
+
+- :func:`parse_timing` — read the GeoClaw ``timing.txt`` a completed run leaves
+  in its output directory into a structured dict.  Standard library only, so it
+  is always available.
+- :func:`plot_performance` — a three-panel wall-time / efficiency comparison
+  across a set of runs.  Needs ``matplotlib`` and ``numpy``; install the optional
+  extra with ``pip install clawpack-batch[analysis]``.  If they are not
+  importable it logs a warning and returns ``None`` rather than raising, mirroring
+  :func:`batch.plot.plot_job`.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from collections.abc import Sequence
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+def parse_timing(job_dir: Path | str) -> dict | None:
+    """Parse the GeoClaw ``timing.txt`` in *job_dir*.
+
+    Parameters
+    ----------
+    job_dir:
+        A job's output directory (``paths.job``).  ``timing.txt`` is expected
+        directly inside it.
+
+    Returns
+    -------
+    dict | None
+        ``None`` if ``timing.txt`` is absent.  Otherwise a dict with:
+
+        ``levels``
+            list of ``{level, wall, cpu, cells}`` per AMR level.
+        ``total_integration``
+            ``{wall, cpu, cells}`` for the integration total (if present).
+        ``components``
+            ``{stepgrid, bc, regrid, output}`` each ``{wall, cpu}`` (present
+            keys only).
+        ``total``
+            ``{wall, cpu}`` overall (if present).
+        ``n_threads``
+            OpenMP thread count reported by the solver (1 if not found).
+    """
+    txt_path = Path(job_dir) / "timing.txt"
+    if not txt_path.exists():
+        return None
+
+    text = txt_path.read_text()
+    result: dict = {"levels": [], "components": {}}
+
+    for m in re.finditer(
+        r"^\s+(\d+)\s+([\d.E+]+)\s+([\d.E+]+)\s+([\d.E+]+)",
+        text,
+        re.MULTILINE,
+    ):
+        result["levels"].append(
+            {
+                "level": int(m.group(1)),
+                "wall": float(m.group(2)),
+                "cpu": float(m.group(3)),
+                "cells": float(m.group(4)),
+            }
+        )
+
+    m = re.search(r"^total\s+([\d.E+]+)\s+([\d.E+]+)\s+([\d.E+]+)", text, re.MULTILINE)
+    if m:
+        result["total_integration"] = {
+            "wall": float(m.group(1)),
+            "cpu": float(m.group(2)),
+            "cells": float(m.group(3)),
+        }
+
+    for key, pattern in [
+        ("stepgrid", r"stepgrid\s+([\d.E+]+)\s+([\d.E+]+)"),
+        ("bc", r"BC/ghost cells\s+([\d.E+]+)\s+([\d.E+]+)"),
+        ("regrid", r"Regridding\s+([\d.E+]+)\s+([\d.E+]+)"),
+        ("output", r"Output \(valout\)\s+([\d.E+]+)\s+([\d.E+]+)"),
+    ]:
+        m = re.search(pattern, text)
+        if m:
+            result["components"][key] = {
+                "wall": float(m.group(1)),
+                "cpu": float(m.group(2)),
+            }
+
+    m = re.search(r"Total time:\s+([\d.E+]+)\s+([\d.E+]+)", text)
+    if m:
+        result["total"] = {"wall": float(m.group(1)), "cpu": float(m.group(2))}
+
+    m = re.search(r"Using (\d+) thread", text)
+    result["n_threads"] = int(m.group(1)) if m else 1
+
+    return result
+
+
+def plot_performance(
+    job_dirs: Sequence[Path | str],
+    labels: Sequence[str] | None = None,
+    out_path: Path | str = "performance.png",
+    *,
+    title: str = "Performance Analysis",
+    dpi: int = 150,
+) -> Path | None:
+    """Three-panel wall-time / efficiency comparison across *job_dirs*.
+
+    Reads ``timing.txt`` from each directory via :func:`parse_timing`, skipping
+    any that lack it.  The figure has three panels:
+
+    - total wall time (bars) with CPU efficiency overlaid, where efficiency is
+      ``cpu / (n_threads * wall)``;
+    - wall time stacked by AMR level;
+    - wall time stacked by solver component (step / BC / regrid / output).
+
+    Parameters
+    ----------
+    job_dirs:
+        Output directories of the runs to compare.
+    labels:
+        One label per directory (parallel to *job_dirs*).  Defaults to each
+        directory's name.
+    out_path:
+        Where to write the PNG.
+    title:
+        Figure suptitle.
+    dpi:
+        Output resolution.
+
+    Returns
+    -------
+    Path | None
+        The path written, or ``None`` if matplotlib/numpy are unavailable or no
+        directory had timing data.
+    """
+    try:
+        import matplotlib
+
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+        import numpy as np
+    except ImportError:
+        logger.warning(
+            "matplotlib/numpy not importable; skipping plot_performance. "
+            "Install the optional extra with: pip install clawpack-batch[analysis]"
+        )
+        return None
+
+    job_dirs = [Path(d) for d in job_dirs]
+    if labels is None:
+        labels = [d.name for d in job_dirs]
+    if len(labels) != len(job_dirs):
+        raise ValueError(
+            f"labels ({len(labels)}) must match job_dirs ({len(job_dirs)})"
+        )
+
+    timings, used_labels = [], []
+    for d, label in zip(job_dirs, labels):
+        t = parse_timing(d)
+        if t is None or "total" not in t:
+            logger.warning("No timing data for %s; skipping.", d)
+            continue
+        timings.append(t)
+        used_labels.append(label)
+
+    if not timings:
+        logger.warning("No timing data found in any job dir; no plot written.")
+        return None
+
+    n = len(timings)
+    x = np.arange(n)
+    tick_fs = max(4, 9 - n // 8)
+
+    fig, axes = plt.subplots(1, 3, figsize=(max(14, n * 0.9 + 4), 6))
+    fig.suptitle(title, fontsize=13)
+
+    # Total wall time (bars) + CPU efficiency (line on a twin axis).
+    ax = axes[0]
+    wall_min = [t["total"]["wall"] / 60 for t in timings]
+    ax.bar(x, wall_min, color="steelblue")
+    ax.set_xticks(x)
+    ax.set_xticklabels(used_labels, rotation=90, fontsize=tick_fs)
+    ax.set_ylabel("Wall Time (min)")
+    ax.set_title("Total Wall Time")
+
+    ax2 = ax.twinx()
+    eff = [
+        t["total"]["cpu"] / (t.get("n_threads", 1) * t["total"]["wall"]) * 100
+        if t["total"]["wall"] > 0
+        else 0.0
+        for t in timings
+    ]
+    ax2.plot(x, eff, "o-", color="orange", label="CPU efficiency")
+    ax2.set_ylabel("CPU Efficiency (%)", color="orange")
+    ax2.tick_params(axis="y", labelcolor="orange")
+    ax2.set_ylim(0, 110)
+
+    # Stacked wall time by AMR level.
+    ax = axes[1]
+    max_lev = max(len(t["levels"]) for t in timings)
+    bottoms = np.zeros(n)
+    for li in range(max_lev):
+        vals = np.array(
+            [
+                t["levels"][li]["wall"] / 60 if li < len(t["levels"]) else 0.0
+                for t in timings
+            ]
+        )
+        ax.bar(x, vals, bottom=bottoms, label=f"Level {li + 1}")
+        bottoms += vals
+    ax.set_xticks(x)
+    ax.set_xticklabels(used_labels, rotation=90, fontsize=tick_fs)
+    ax.set_ylabel("Wall Time (min)")
+    ax.set_title("Time by AMR Level")
+    ax.legend(fontsize=8)
+
+    # Stacked wall time by solver component.
+    ax = axes[2]
+    bottoms = np.zeros(n)
+    for key, lbl in [
+        ("stepgrid", "Step (PDE)"),
+        ("bc", "BC/Ghost"),
+        ("regrid", "Regrid"),
+        ("output", "Output"),
+    ]:
+        vals = np.array(
+            [t["components"].get(key, {}).get("wall", 0.0) / 60 for t in timings]
+        )
+        ax.bar(x, vals, bottom=bottoms, label=lbl)
+        bottoms += vals
+    ax.set_xticks(x)
+    ax.set_xticklabels(used_labels, rotation=90, fontsize=tick_fs)
+    ax.set_ylabel("Wall Time (min)")
+    ax.set_title("Time by Component")
+    ax.legend(fontsize=8)
+
+    fig.tight_layout()
+    out_path = Path(out_path)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(out_path, dpi=dpi, bbox_inches="tight")
+    plt.close(fig)
+    logger.info("Performance plot saved: %s", out_path)
+    return out_path

--- a/batch/cli.py
+++ b/batch/cli.py
@@ -387,8 +387,7 @@ def execute(
         logger.info("Setup complete for %d job(s).", len(paths))
         return []
 
-    if wait is None:
-        wait = scheduler == "local"
-    results = ctrl.run(wait=wait)
+    should_wait = (scheduler == "local") if wait is None else wait
+    results = ctrl.run(wait=should_wait)
     report_results(results)
     return results

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,6 +45,7 @@ Start here and read in order, or jump to the task you have in front of you:
 | `ClobberPolicy` | Controls what happens when output already exists: `OVERWRITE`, `ERROR`, `SKIP`. |
 | `plot_job` | Runs plotclaw after a job completes; handles missing visclaw gracefully. |
 | `product_sweep` / `zip_sweep` | Build job lists from parameter grids (`batch.sweep`). |
+| `parse_timing` / `plot_performance` | Parse a run's `timing.txt` and plot cross-run performance (`batch.analysis`). |
 
 The workflow is always the same shape:
 
@@ -61,6 +62,7 @@ from batch import SerialExecutor, ParallelExecutor
 from batch import SLURMExecutor, SLURMResources
 from batch import PBSExecutor, PBSResources
 from batch import plot_job
+from batch import parse_timing, plot_performance
 from batch.sweep import product_sweep, zip_sweep
 ```
 

--- a/docs/postprocessing.md
+++ b/docs/postprocessing.md
@@ -109,9 +109,44 @@ fig.savefig(successful[0].paths.job.parent / "ensemble_comparison.png")
 The `plot_ensemble` function in `examples/local_ensemble/run_batch.py` is a
 complete version of this pattern.
 
-> **Note.** The `batch.analysis` module is a placeholder and currently raises
-> `NotImplementedError` — there is no built-in cross-run analysis API yet.
-> Cross-run analysis is done manually via the `results` list as shown above.
+---
+
+## `batch.analysis`: timing and performance
+
+For GeoClaw's per-run `timing.txt`, `batch.analysis` provides two ready-made
+tools so you don't have to hand-parse it.
+
+`parse_timing(job_dir)` reads the `timing.txt` in a job's output directory into a
+dict (per-AMR-level wall/cpu/cells, solver-component breakdown, overall total, and
+the OpenMP thread count), or returns `None` if the file isn't there:
+
+```python
+from batch import parse_timing
+
+t = parse_timing(result.paths.job)
+if t:
+    print(t["total"]["wall"], "s wall,", t["n_threads"], "threads")
+```
+
+`plot_performance(job_dirs, labels, out_path)` builds a three-panel comparison
+across runs — total wall time with CPU efficiency overlaid, wall time by AMR
+level, and wall time by solver component:
+
+```python
+from batch import plot_performance
+
+successful = [r for r in results if r.success]
+plot_performance(
+    [r.paths.job for r in successful],
+    labels=[r.job.prefix for r in successful],
+    out_path="performance.png",
+)
+```
+
+`parse_timing` is standard-library only. `plot_performance` needs matplotlib and
+numpy — install them with the optional extra, `pip install clawpack-batch[analysis]`;
+without them it logs a warning and returns `None` rather than raising (like
+`plot_job`).
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,10 +13,16 @@ requires-python = ">=3.10"
 dependencies = []
 
 [project.optional-dependencies]
+analysis = [
+    "matplotlib",
+    "numpy",
+]
 dev = [
     "pytest>=7",
     "pytest-cov",
     "ruff",
+    "matplotlib",
+    "numpy",
 ]
 lint = [
     "ruff",

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -1,0 +1,121 @@
+"""Tests for batch.analysis.
+
+parse_timing is pure and always tested.  plot_performance is guarded by
+importorskip so the suite still runs without matplotlib/numpy installed.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from batch.analysis import parse_timing, plot_performance
+
+# A synthetic GeoClaw timing.txt exercising every field parse_timing reads.
+TIMING_TXT = """\
+ Timing summary
+ Level      Wall        CPU        Cells
+     1     10.0        80.0       1000.0
+     2     20.0       160.0       2000.0
+total       30.0       240.0       3000.0
+
+ stepgrid            25.0        200.0
+ BC/ghost cells       3.0         24.0
+ Regridding           1.0          8.0
+ Output (valout)      1.0          8.0
+
+ Total time:         30.5        244.0
+ Using 8 threads
+"""
+
+
+def write_timing(job_dir: Path, text: str = TIMING_TXT) -> Path:
+    job_dir.mkdir(parents=True, exist_ok=True)
+    (job_dir / "timing.txt").write_text(text)
+    return job_dir
+
+
+# ---------------------------------------------------------------------------
+# parse_timing
+# ---------------------------------------------------------------------------
+
+
+class TestParseTiming:
+    def test_missing_file_returns_none(self, tmp_path):
+        assert parse_timing(tmp_path) is None
+
+    def test_levels(self, tmp_path):
+        t = parse_timing(write_timing(tmp_path / "job"))
+        assert len(t["levels"]) == 2
+        assert t["levels"][0] == {
+            "level": 1,
+            "wall": 10.0,
+            "cpu": 80.0,
+            "cells": 1000.0,
+        }
+        assert t["levels"][1]["level"] == 2
+
+    def test_total_integration(self, tmp_path):
+        t = parse_timing(write_timing(tmp_path / "job"))
+        assert t["total_integration"] == {
+            "wall": 30.0,
+            "cpu": 240.0,
+            "cells": 3000.0,
+        }
+
+    def test_components(self, tmp_path):
+        t = parse_timing(write_timing(tmp_path / "job"))
+        assert t["components"]["stepgrid"] == {"wall": 25.0, "cpu": 200.0}
+        assert t["components"]["bc"] == {"wall": 3.0, "cpu": 24.0}
+        assert t["components"]["regrid"] == {"wall": 1.0, "cpu": 8.0}
+        assert t["components"]["output"] == {"wall": 1.0, "cpu": 8.0}
+
+    def test_total_and_threads(self, tmp_path):
+        t = parse_timing(write_timing(tmp_path / "job"))
+        assert t["total"] == {"wall": 30.5, "cpu": 244.0}
+        assert t["n_threads"] == 8
+
+    def test_threads_default_when_absent(self, tmp_path):
+        # A file with only a total line: n_threads falls back to 1.
+        t = parse_timing(write_timing(tmp_path / "job", " Total time:  5.0  5.0\n"))
+        assert t["n_threads"] == 1
+        assert t["total"] == {"wall": 5.0, "cpu": 5.0}
+
+    def test_accepts_str_path(self, tmp_path):
+        job = write_timing(tmp_path / "job")
+        assert parse_timing(str(job)) is not None
+
+
+# ---------------------------------------------------------------------------
+# plot_performance (needs matplotlib + numpy)
+# ---------------------------------------------------------------------------
+
+
+class TestPlotPerformance:
+    def test_writes_png_and_returns_path(self, tmp_path):
+        pytest.importorskip("matplotlib")
+        pytest.importorskip("numpy")
+        dirs = [write_timing(tmp_path / f"job{i}") for i in range(3)]
+        out = plot_performance(dirs, out_path=tmp_path / "perf.png")
+        assert out == tmp_path / "perf.png"
+        assert out.exists() and out.stat().st_size > 0
+
+    def test_default_labels_from_dir_names(self, tmp_path):
+        pytest.importorskip("matplotlib")
+        dirs = [write_timing(tmp_path / "runA"), write_timing(tmp_path / "runB")]
+        out = plot_performance(dirs, out_path=tmp_path / "p.png")
+        assert out is not None
+
+    def test_none_when_no_timing_data(self, tmp_path):
+        pytest.importorskip("matplotlib")
+        empty = [tmp_path / "a", tmp_path / "b"]
+        for d in empty:
+            d.mkdir()
+        assert plot_performance(empty, out_path=tmp_path / "p.png") is None
+
+    def test_label_count_mismatch_raises(self, tmp_path):
+        pytest.importorskip("matplotlib")
+        dirs = [write_timing(tmp_path / "j0"), write_timing(tmp_path / "j1")]
+        with pytest.raises(ValueError, match="match"):
+            plot_performance(dirs, labels=["only-one"], out_path=tmp_path / "p.png")


### PR DESCRIPTION
## What

Fills in the `batch.analysis` stub (previously `raise NotImplementedError`) with
the GeoClaw timing/performance tooling generalized out of the ETC project driver.

- **`parse_timing(job_dir) → dict | None`** — parses a run's `timing.txt` into
  `{levels, total_integration, components, total, n_threads}`, or `None` if the
  file isn't there. Standard-library only, so it's always importable.
- **`plot_performance(job_dirs, labels, out_path, *, title, dpi) → Path | None`**
  — a three-panel comparison across runs: total wall time with CPU efficiency
  overlaid, wall time stacked by AMR level, and wall time stacked by solver
  component. Reads each dir via `parse_timing`, skipping any without timing data.

## Dependencies

`batch` stays dependency-free at its core: `parse_timing` uses only the stdlib.
`plot_performance` lazy-imports `matplotlib`/`numpy` and, if they're absent, logs
a warning and returns `None` rather than raising — the same graceful degradation
as `plot_job` with a missing visclaw. A new optional extra installs them:
`pip install clawpack-batch[analysis]` (also added to the `dev` extra so CI
exercises the plot path).

## Docs

Removed the "placeholder / NotImplementedError" note in the post-processing guide,
added a `batch.analysis` section there, and listed the two functions in the docs
index.

## Tests

`tests/test_analysis.py`: `parse_timing` against a synthetic `timing.txt`
(levels, components, totals, thread count; `None` on missing file; `n_threads`
fallback), and `plot_performance` guarded by `pytest.importorskip("matplotlib")`
(writes a PNG and returns its path; `None` when no dir has timing data; raises on
a label/dir count mismatch).

Full suite: 209 passed; `ruff check` + `ruff format` clean.

## Also included

A one-line type narrowing in `batch/cli.py::execute` (`wait: bool | None` →
a resolved local before `run(wait=…)`); no behavior change. Split as its own
commit on the branch.